### PR TITLE
fix roby command with argument

### DIFF
--- a/source/basics/getting_started.html.md
+++ b/source/basics/getting_started.html.md
@@ -31,8 +31,9 @@ Let's create a new bundle. In your Rock's workspace do
 ~~~
 acd
 cd bundles
-roby init syskit_basics
+mkdir syskit_basics
 cd syskit_basics
+roby init
 ~~~
 
 This creates a Roby application, Roby being the underlying application framework


### PR DESCRIPTION
this fix the following error:

```
diego@diego-bir ~/dev.vanilla/bundles $ roby init syskit_basics
ERROR: "roby init" was called with arguments ["syskit_basics"]
Usage: "roby Deprecated"
```
